### PR TITLE
Fixed ui.message from emr.user.* to coreapps.user.*

### DIFF
--- a/omod/src/main/webapp/fragments/htmlform/enterHtmlForm.gsp
+++ b/omod/src/main/webapp/fragments/htmlform/enterHtmlForm.gsp
@@ -115,11 +115,11 @@
                         <td colspan="2"><b>${ ui.message("htmlformentry.loginAgainMessage") }</b></td>
                     </tr>
                     <tr>
-                        <td align="right"><b>${ ui.message("emr.user.username") }:</b></td>
+                        <td align="right"><b>${ ui.message("coreapps.user.username") }:</b></td>
                         <td><input type="text" id="passwordPopupUsername"/></td>
                     </tr>
                     <tr>
-                        <td align="right"><b>${ ui.message("emr.user.password") }:</b></td>
+                        <td align="right"><b>${ ui.message("coreapps.user.password") }:</b></td>
                         <td><input type="password" id="passwordPopupPassword"/></td>
                     </tr>
                     <tr>


### PR DESCRIPTION
The popup box was referencing the emr.user.username module message property, but that doesn't exist. The reference application uses the property in coreapps for both the username and password.
Changed: 
emr.user.username to coreapps.user.username
emr.user.password to coreapps.user.password