### PR TITLE
Fixed broken breadcrumb

### DIFF
--- a/omod/src/main/webapp/pages/htmlform/editHtmlFormWithSimpleUi.gsp
+++ b/omod/src/main/webapp/pages/htmlform/editHtmlFormWithSimpleUi.gsp
@@ -29,7 +29,7 @@ ${ ui.includeFragment("coreapps", "patientHeader", [ patient: patient ]) }
     var breadcrumbs = _.flatten([
         { icon: "icon-home", link: '/' + OPENMRS_CONTEXT_PATH + '/index.htm' },
         ${ breadcrumbMiddle },
-        { label: "${ ui.escapeJs(ui.message("emr.editHtmlForm.breadcrumb", ui.format(htmlForm.form))) }" }
+        { label: "${ ui.escapeJs(ui.format(htmlForm.form)) }" }
     ]);
 
     jQuery(function() {


### PR DESCRIPTION
The UI was displaying "emr.editHtmlForm.breadcrumb" instead of the name of the form. This fix is the same as in the enterHtmlFormWithSimpleUi.gsp page which displays the form name properly.