### PR TITLE
Updating viewEncounterWithHtmlForm to fix the breadcrumb and edit button...

### DIFF
--- a/omod/src/main/java/org/openmrs/module/htmlformentryui/page/controller/htmlform/ViewEncounterWithHtmlFormPageController.java
+++ b/omod/src/main/java/org/openmrs/module/htmlformentryui/page/controller/htmlform/ViewEncounterWithHtmlFormPageController.java
@@ -30,7 +30,7 @@ public class ViewEncounterWithHtmlFormPageController {
             returnUrl = ui.pageLink("coreapps", "patientdashboard/patientDashboard", SimpleObject.create("patientId", patient.getId()));
         }
         if (StringUtils.isEmpty(returnLabel)) {
-            returnLabel = ui.escapeJs(ui.format(patient));
+            returnLabel = ui.escapeJs(ui.format(patient.getPatient()));
         }
 
         model.addAttribute("patient", patient);

--- a/omod/src/main/webapp/pages/htmlform/viewEncounterWithHtmlForm.gsp
+++ b/omod/src/main/webapp/pages/htmlform/viewEncounterWithHtmlForm.gsp
@@ -41,8 +41,9 @@
         ${ ui.message("uicommons.print") }
     </a>
     <a class="button" href="${ ui.pageLink("htmlformentryui", "htmlform/editHtmlFormWith" + editStyle + "Ui", [
-            encounterId: encounter.uuid,
-            patientId: patient.patient.uuid
+            encounterId: encounter.id,
+            patientId: patient.patient.uuid,
+            returnUrl: returnUrl
     ]) }">
         <i class="icon-pencil"></i>
         ${ ui.message("uicommons.edit") }


### PR DESCRIPTION
... link.
Here is the reasoning behind these changes:
1) The patientDomainWrapper was being passed as the returnLabel, so I changed it to patient.getPatient() to ensure the patient's name is returned in the label.

2) The edit button link was passing the encounter.uuid which caused an error in the editHtmlFormWithSimpleUi.

3) I thought it would be appropriate to forward on the returnUrl in the edit button so that the user is returned to their original location when they exit the form after editing.

Sincerely,
Craig