### PR TITLE
HTML-709:Form name localisation

### DIFF
--- a/omod/src/main/webapp/pages/htmlform/editHtmlFormWithSimpleUi.gsp
+++ b/omod/src/main/webapp/pages/htmlform/editHtmlFormWithSimpleUi.gsp
@@ -29,7 +29,7 @@ ${ ui.includeFragment("coreapps", "patientHeader", [ patient: patient ]) }
     var breadcrumbs = _.flatten([
         { icon: "icon-home", link: '/' + OPENMRS_CONTEXT_PATH + '/index.htm' },
         ${ breadcrumbMiddle },
-        { label: "${ ui.escapeJs(ui.message("coreapps.editHtmlForm.breadcrumb", ui.format(htmlForm.form))) }" }
+        { label: "${ ui.escapeJs(ui.message("coreapps.editHtmlForm.breadcrumb", ui.message(ui.format(htmlForm.form)))) }" }
     ]);
 
     jQuery(function() {
@@ -51,33 +51,12 @@ ${ ui.includeFragment("coreapps", "patientHeader", [ patient: patient ]) }
         // clicking the save form link should have the same functionality as clicking on the confirmation section title (ie, jumps to confirmation)
         jq('#save-form').click(function() {
             NavigatorController.getSectionById("confirmation").title.click();
-        });
-
-      <% if (featureToggles.isFeatureEnabled("htmlformentryui.simpleform.navbuttons")) { %>
-          jq('#step-backward').click(function() {
-            NavigatorController.stepBackward();
-          });
-
-          jq('#step-forward').click(function() {
-            NavigatorController.stepForward();
-          });
-      <% } %>
+        })
 
     });
 </script>
 
 <div id="form-actions-container">
-
-    <% if (featureToggles.isFeatureEnabled("htmlformentryui.simpleform.navbuttons")) { %>
-        <a id="step-backward" style="float: left">
-            << Back
-        </a>
-        <a id="step-forward">
-            Forward >>
-        </a>
-        &nbsp;&nbsp;&nbsp;
-    <% } %>
-
     <a id="save-form">
         <i class="icon-save small"></i>
         ${ ui.message("htmlformentryui.saveForm") }

--- a/omod/src/main/webapp/pages/htmlform/editHtmlFormWithStandardUi.gsp
+++ b/omod/src/main/webapp/pages/htmlform/editHtmlFormWithStandardUi.gsp
@@ -10,7 +10,7 @@
     var breadcrumbs = _.flatten([
         { icon: "icon-home", link: '/' + OPENMRS_CONTEXT_PATH + '/index.htm' },
         ${ breadcrumbMiddle },
-        { label: "${ ui.escapeJs(ui.message("coreapps.editHtmlForm.breadcrumb", ui.format(htmlForm.form))) }" }
+        { label: "${ ui.escapeJs(ui.message("coreapps.editHtmlForm.breadcrumb", ui.message(ui.format(htmlForm.form)))) }" }
     ]);
 
     jq(function() {

--- a/omod/src/main/webapp/pages/htmlform/enterHtmlFormWithSimpleUi.gsp
+++ b/omod/src/main/webapp/pages/htmlform/enterHtmlFormWithSimpleUi.gsp
@@ -52,34 +52,12 @@ ${ ui.includeFragment("coreapps", "patientHeader", [ patient: patient ]) }
         // clicking the save form link should have the same functionality as clicking on the confirmation section title (ie, jumps to confirmation)
         jq('#save-form').click(function() {
             NavigatorController.getSectionById("confirmation").title.click();
-        });
-
-
-      <% if (featureToggles.isFeatureEnabled("htmlformentryui.simpleform.navbuttons")) { %>
-          jq('#step-backward').click(function() {
-            NavigatorController.stepBackward();
-          });
-
-          jq('#step-forward').click(function() {
-            NavigatorController.stepForward();
-          });
-      <% } %>
+        })
 
     });
 </script>
 
 <div id="form-actions-container">
-
-    <% if (featureToggles.isFeatureEnabled("htmlformentryui.simpleform.navbuttons")) { %>
-        <a id="step-backward" style="float: left">
-            << Back
-        </a>
-        <a id="step-forward">
-            Forward >>
-        </a>
-        &nbsp;&nbsp;&nbsp;
-    <% } %>
-
     <a id="save-form">
         <i class="icon-save small"></i>
         ${ ui.message("htmlformentryui.saveForm") }

--- a/omod/src/main/webapp/pages/htmlform/enterHtmlFormWithStandardUi.gsp
+++ b/omod/src/main/webapp/pages/htmlform/enterHtmlFormWithStandardUi.gsp
@@ -13,7 +13,7 @@
     var breadcrumbs = _.flatten([
         { icon: "icon-home", link: '/' + OPENMRS_CONTEXT_PATH + '/index.htm' },
         ${ breadcrumbMiddle },
-        { label: "${ ui.escapeJs(ui.format(htmlForm.form)) }" }
+        { label: "${ ui.message(ui.escapeJs(ui.format(htmlForm.form)) )}" }
     ]);
 
     jq(function() {

--- a/omod/src/main/webapp/pages/htmlform/viewEncounterWithHtmlForm.gsp
+++ b/omod/src/main/webapp/pages/htmlform/viewEncounterWithHtmlForm.gsp
@@ -15,7 +15,7 @@
     var breadcrumbs = [
         { icon: "icon-home", link: '/' + OPENMRS_CONTEXT_PATH + '/index.htm' },
         { label: "${ ui.escapeJs(returnLabel) }", link: "${ ui.escapeJs(returnUrl) }" },
-        { label: "${ ui.escapeJs(ui.message("htmlformentryui.viewHtmlForm.breadcrumb", ui.format(htmlForm.form))) }" }
+        { label: "${ ui.escapeJs(ui.message("htmlformentryui.viewHtmlForm.breadcrumb", ui.message(ui.format(htmlForm.form)))) }" }
     ];
 </script>
 


### PR DESCRIPTION
HTML-709:Form name localisation in breadcrumb
Description
Current implementation of HTMLFormEntryUI doesn't support form name localisation.
If locale is change then form name  doesn't translate in breadcrumb to their respective locale.
For example:
In en locale form name is Trauma form and If locale is change to fr then form name must be translate to formulaire de traumatisme.

Jira link:
https://issues.openmrs.org/browse/HTML-709