### PR TITLE
HTML-706: Obs group members should also be considered when initializing the fragment

### DIFF
--- a/api/src/main/java/org/openmrs/module/htmlformentryui/element/ObsFromFragmentElement.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentryui/element/ObsFromFragmentElement.java
@@ -210,7 +210,7 @@ public class ObsFromFragmentElement implements HtmlGeneratorElement, FormSubmiss
 			if (existingEncounter != null) {
 				// The existingEncounter usually has stale references; pull a clean copy from the database
 				Encounter encounter = Context.getEncounterService().getEncounter(existingEncounter.getEncounterId());
-				for (Obs candidate : encounter.getObsAtTopLevel(false)) {
+				for (Obs candidate : encounter.getAllObs()) {
 					if (candidate.getConcept().equals(concept) && candidate.getComment().equals(getFormFieldName())) {
 						Object initialValue = getObsValue(candidate);
 						if (initialValue != null) {

--- a/api/src/test/java/org/openmrs/module/htmlformentryui/element/ObsFromFragmentElementTest.java
+++ b/api/src/test/java/org/openmrs/module/htmlformentryui/element/ObsFromFragmentElementTest.java
@@ -90,7 +90,7 @@ public class ObsFromFragmentElementTest {
 		when(session.getContext()).thenReturn(context);
 		when(session.getSubmissionActions()).thenReturn(submissionActions);
 		when(context.getExistingEncounter()).thenReturn(encounter);
-		when(encounter.getObsAtTopLevel(false)).thenReturn(Collections.singleton(obs));
+		when(encounter.getAllObs()).thenReturn(Collections.singleton(obs));
 		when(obs.getConcept()).thenReturn(concept);
 		when(obs.getComment()).thenReturn(formFieldName);
 		fragmentParams = new HashMap<String, Object>();


### PR DESCRIPTION
Just used this core feature `Encounter#getAllObs()` instead of having to grep through all top level Observations(`ObsGroup` owners). Since this is a core feature, it's sort of trivial to have a unit test!

```java
    @Test
    // Well this is not a bug as such, but rather it was my wrong use of the API
    public void reproducingBugWithObsGroupTag() {
		// setup
		Obs groupOwner = new Obs();
		groupOwner.setId(2);
		Obs member = new Obs();
		member.setId(3);
		groupOwner.addGroupMember(member);
		Encounter enc = new Encounter();
		enc.addObs(groupOwner);
		enc.addObs(member);
		
		// replay
		Set<Obs> topLevelObs = enc.getObsAtTopLevel(false);
		
		// verify
		Assert.assertEquals(1, topLevelObs.size());
		// It's the group owners that are at the top levels
		// members aren't returned at this level, to get the members you
		// definitely wanna grep through the group owner!
		// I definitely would have used `Encounter#getAllObs()`
		Assert.assertEquals(groupOwner, topLevelObs.iterator().next());
	}

```