### PR TITLE
HTML-706: Parses comma-separated "classes" param into an array.

### DIFF
--- a/api/src/main/java/org/openmrs/module/htmlformentryui/element/ObsFromFragmentElement.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentryui/element/ObsFromFragmentElement.java
@@ -5,6 +5,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -219,6 +220,11 @@ public class ObsFromFragmentElement implements HtmlGeneratorElement, FormSubmiss
 					}
 				}
 			} 
+		}
+		if (fragmentParams.containsKey("classes")) {
+			String classes = (String) fragmentParams.get("classes");
+			// If the classes param was provided, convert it's value to a list in order to be consumable by UICM fragments
+			fragmentParams.replace("classes", Arrays.asList(classes.split(",")));
 		}
 	}
 	

--- a/api/src/main/java/org/openmrs/module/htmlformentryui/element/ObsFromFragmentElement.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentryui/element/ObsFromFragmentElement.java
@@ -223,7 +223,6 @@ public class ObsFromFragmentElement implements HtmlGeneratorElement, FormSubmiss
 		}
 		if (fragmentParams.containsKey("classes")) {
 			String classes = (String) fragmentParams.get("classes");
-			// If the classes param was provided, convert it's value to a list in order to be consumable by UICM fragments
 			fragmentParams.replace("classes", Arrays.asList(classes.split(",")));
 		}
 	}

--- a/api/src/test/java/org/openmrs/module/htmlformentryui/element/ObsFromFragmentElementTest.java
+++ b/api/src/test/java/org/openmrs/module/htmlformentryui/element/ObsFromFragmentElementTest.java
@@ -222,7 +222,6 @@ public class ObsFromFragmentElementTest {
 		List<String> classes = (List<String>) fragmentParams.get("classes");
 		Assert.assertThat(classes.size(), is(2));
 		Assert.assertThat(classes, containsInAnyOrder("required", "form-control"));
-
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/module/htmlformentryui/element/ObsFromFragmentElementTest.java
+++ b/api/src/test/java/org/openmrs/module/htmlformentryui/element/ObsFromFragmentElementTest.java
@@ -9,6 +9,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -205,6 +207,22 @@ public class ObsFromFragmentElementTest {
 		// Verify
 		String selectedOption = (String) element.getFragmentParams().get("initialValue");	
 		Assert.assertEquals("Concept Answer 1", selectedOption);
+	}
+	
+	@Test
+	public void initializeFragment_shouldConvertClassesParamToList() {
+		// Setup
+		element.setConcept(createMockedCodedConcept());
+		fragmentParams.put("classes", "required,form-control");
+		
+		// Replay 
+		element.initializeFragment(context);
+		
+		// Verify
+		List<String> classes = (List<String>) fragmentParams.get("classes");
+		Assert.assertThat(classes.size(), is(2));
+		Assert.assertThat(classes, containsInAnyOrder("required", "form-control"));
+
 	}
 	
 	@Test


### PR DESCRIPTION
This is a followup commit on: https://issues.openmrs.org/browse/HTML-706
