### PR TITLE
HTML-714: View mode 'Custom Print' URL to target a single encounter.

### DIFF
--- a/omod/src/main/webapp/pages/htmlform/viewEncounterWithHtmlForm.gsp
+++ b/omod/src/main/webapp/pages/htmlform/viewEncounterWithHtmlForm.gsp
@@ -40,7 +40,7 @@
 <% if (customPrintPageName == null || customPrintPageName.isEmpty()) { %>
         <a class="button" id="print-button" href="javascript:window.print()">
 <% } else { %>
-        <a class="button" id="print-button" href="${ui.pageLink(customPrintProvider, customPrintPageName, [patientId: patient.patient.id, encounterUuid: encounter.uuid, target: customPrintTarget])}" target="${customPrintTarget}">
+        <a class="button" id="print-button" href="${ui.pageLink(customPrintProvider, customPrintPageName, [encounterUuid: encounter.uuid, contentDisposition: 'inline'])}" target="${customPrintTarget}">
 <% } %>
 
         <i class="icon-print"></i>


### PR DESCRIPTION
 * Removes redundant patient information (since patient information is already part of an encounter)
 * Changes GET param `target` to `contentDisposition` (since it makes more sense for server-side controllers)