### PR TITLE
HTML-706: <obsFromFragment/> initialising existing obs when rendering.

### DIFF
--- a/api/src/test/java/org/openmrs/module/htmlformentryui/element/ObsFromFragmentElementTest.java
+++ b/api/src/test/java/org/openmrs/module/htmlformentryui/element/ObsFromFragmentElementTest.java
@@ -323,7 +323,6 @@ public class ObsFromFragmentElementTest {
 	public void handleSubmission_shouldUpdateAnObsIfInEditMode() {
 		// Setup
 		when(context.getMode()).thenReturn(FormEntryContext.Mode.EDIT);
-		when(context.removeExistingObs(concept)).thenReturn(Arrays.asList(obs));
 		when(obs.getValueBoolean()).thenReturn(true);
 		when(obs.getComment()).thenReturn(formFieldName);
 		when(request.getParameter(formFieldName)).thenReturn("false");
@@ -332,6 +331,7 @@ public class ObsFromFragmentElementTest {
 		dateDatatype.setUuid(ConceptDatatype.BOOLEAN_UUID);
 		when(concept.getDatatype()).thenReturn(dateDatatype);
 		element.setConcept(concept);
+		element.setExistingObs(obs);
 		
 		doAnswer(new Answer() {
 


### PR DESCRIPTION
The `<obsFromFragment/>` tag doesn't handle updating of a field value(an observation) that exists in an _Obs group_ properly. What happens is the submission handler fails to choose the existing _Obs_ for _voiding_ and only creates a new _Obs_ without _voiding/retiring_ the old one.

This is a followup commit with minor changes that resolves the above issue.

Ticket: https://issues.openmrs.org/browse/HTML-706