### PR TITLE
HTML-706: Added Spring tests and fixed UI datepicker icon alignment.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,97 +1,95 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>org.openmrs.module</groupId>
-		<artifactId>htmlformentryui</artifactId>
-		<version>1.11.0-SNAPSHOT</version>
-	</parent>
+    <parent>
+        <groupId>org.openmrs.module</groupId>
+        <artifactId>htmlformentryui</artifactId>
+        <version>1.11.0-SNAPSHOT</version>
+    </parent>
 
-	<artifactId>htmlformentryui-api</artifactId>
-	<packaging>jar</packaging>
-	<name>HTML Form Entry UI Framework Integration Module API</name>
-	<description>API project for HTMLFormEntryUIFrameworkIntegration</description>
-
-	<dependencies>
-	
-		<dependency>
-		  <groupId>org.apache.httpcomponents</groupId>
-		  <artifactId>httpclient</artifactId>
-		  <version>4.5.9</version>
-		</dependency>
-		
-		<!-- jars required only to run test scripts (scope=test) -->
-		<dependency>
-			<groupId>org.openmrs.web</groupId>
-			<artifactId>openmrs-web</artifactId>
-			<version>${openMRSVersion}</version>
-		</dependency>
-		<dependency>
+    <artifactId>htmlformentryui-api</artifactId>
+    <packaging>jar</packaging>
+    <name>HTML Form Entry UI Framework Integration Module API</name>
+    <description>API project for HTMLFormEntryUIFrameworkIntegration</description>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.9</version>
+        </dependency>
+        <!-- jars required only to run test scripts (scope=test) -->
+        <dependency>
+            <groupId>org.openmrs.web</groupId>
+            <artifactId>openmrs-web</artifactId>
+            <version>${openMRSVersion}</version>
+        </dependency>
+        <dependency>
             <groupId>org.openmrs.api</groupId>
             <artifactId>openmrs-api</artifactId>
             <version>${openMRSVersion}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-		<dependency>
+        <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-mapper-asl</artifactId>
             <version>1.5.0</version>
             <type>jar</type>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-core-asl</artifactId>
             <version>1.5.0</version>
             <type>jar</type>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
-		<dependency>
-			<groupId>org.codehaus.groovy</groupId>
-			<artifactId>groovy</artifactId>
-			<version>1.8.3</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>cglib</groupId>
-			<artifactId>cglib</artifactId>
-			<version>2.2.2</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>xalan</groupId>
-			<artifactId>xalan</artifactId>
-			<version>2.7.1</version>
-			<scope>test</scope>
-		</dependency>
-           <dependency>
-               <groupId>joda-time</groupId>
-               <artifactId>joda-time</artifactId>
-               <version>2.9.2</version>
-           </dependency>
-           <dependency>
-               <groupId>org.joda</groupId>
-               <artifactId>joda-convert</artifactId>
-               <version>1.2</version>
-           </dependency>
-				
-	</dependencies>
-	
-	<build>
-		<resources>
-			<resource>
-				<directory>src/main/resources</directory>
-				<filtering>true</filtering>
-			</resource>
-		</resources>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>1.8.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>cglib</groupId>
+            <artifactId>cglib</artifactId>
+            <version>2.2.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>xalan</groupId>
+            <artifactId>xalan</artifactId>
+            <version>2.7.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>2.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.joda</groupId>
+            <artifactId>joda-convert</artifactId>
+            <version>1.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
-		<testResources>
-			<testResource>
-				<directory>src/test/resources</directory>
-				<filtering>true</filtering>
-			</testResource>
-		</testResources>
-	</build>
-
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
+    </build>
+    
 </project>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,6 +20,62 @@
 		  <version>4.5.9</version>
 		</dependency>
 		
+		<!-- jars required only to run test scripts (scope=test) -->
+		<dependency>
+			<groupId>org.openmrs.web</groupId>
+			<artifactId>openmrs-web</artifactId>
+			<version>${openMRSVersion}</version>
+		</dependency>
+		<dependency>
+            <groupId>org.openmrs.api</groupId>
+            <artifactId>openmrs-api</artifactId>
+            <version>${openMRSVersion}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+		<dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-mapper-asl</artifactId>
+            <version>1.5.0</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-core-asl</artifactId>
+            <version>1.5.0</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
+		<dependency>
+			<groupId>org.codehaus.groovy</groupId>
+			<artifactId>groovy</artifactId>
+			<version>1.8.3</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>cglib</groupId>
+			<artifactId>cglib</artifactId>
+			<version>2.2.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>xalan</groupId>
+			<artifactId>xalan</artifactId>
+			<version>2.7.1</version>
+			<scope>test</scope>
+		</dependency>
+           <dependency>
+               <groupId>joda-time</groupId>
+               <artifactId>joda-time</artifactId>
+               <version>2.9.2</version>
+           </dependency>
+           <dependency>
+               <groupId>org.joda</groupId>
+               <artifactId>joda-convert</artifactId>
+               <version>1.2</version>
+           </dependency>
+				
 	</dependencies>
 	
 	<build>

--- a/api/src/main/java/org/openmrs/module/htmlformentryui/element/ObsFromFragmentElement.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentryui/element/ObsFromFragmentElement.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Concept;
 import org.openmrs.ConceptAnswer;
@@ -88,6 +87,7 @@ public class ObsFromFragmentElement implements HtmlGeneratorElement, FormSubmiss
 			return;
 		}
 		String formFieldName = getFormFieldName();
+
 		if (formFieldName != null) {
 			String valueText = request.getParameter(formFieldName);
 			if (StringUtils.isBlank(valueText)) {
@@ -96,6 +96,7 @@ public class ObsFromFragmentElement implements HtmlGeneratorElement, FormSubmiss
 			if (session.getContext().getMode().equals(FormEntryContext.Mode.EDIT) && existingObs != null) {				
 				session.getSubmissionActions().modifyObs(existingObs, concept, convertToType(valueText), 
 						new Date(), null, formFieldName);
+				return;
 			}
 			session.getSubmissionActions().createObs(concept, convertToType(valueText), new Date(), null,
 					// Set the formFieldName of the widget as the Obs comment 
@@ -206,14 +207,15 @@ public class ObsFromFragmentElement implements HtmlGeneratorElement, FormSubmiss
 					// The existingEncounter usually has stale references; pull a clean copy from the database
 					Encounter encounter = Context.getEncounterService().getEncounter(existingEncounter.getEncounterId());
 					for (Obs candidate : encounter.getAllObs()) {
-						if (candidate.getConcept().equals(concept) && candidate.getComment().equals(getFormFieldName())) {
+						String formFieldName = candidate.getComment() != null ? candidate.getComment() : "";
+						if (candidate.getConcept().equals(concept) && formFieldName.equals(getFormFieldName())) {
 							// Initialise existingObs
 							existingObs = candidate;		
 							Object initialValue = getObsValue(existingObs);
 							if (initialValue != null) {
 								fragmentParams.put(initFragmentParamName, initialValue);
 							}
-							return;
+							break;
 						}
 					}
 				}			

--- a/api/src/test/java/org/openmrs/module/htmlformentryui/tag/ObsFromFragmentTagTest.java
+++ b/api/src/test/java/org/openmrs/module/htmlformentryui/tag/ObsFromFragmentTagTest.java
@@ -1,0 +1,193 @@
+package org.openmrs.module.htmlformentryui.tag;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.Obs;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.htmlformentry.HtmlFormEntryUtil;
+import org.openmrs.module.htmlformentry.RegressionTestHelper;
+import org.openmrs.module.htmlformentry.handler.SubstitutionTagHandler;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+public class ObsFromFragmentTagTest extends BaseModuleContextSensitiveTest {
+		
+	@Before
+	public void setup() throws Exception {
+		executeDataSet("org/openmrs/module/htmlformentry/include/RegressionTest-data-openmrs-1.10.xml");
+		HtmlFormEntryUtil.getService().addHandler("obsFromFragment", Context.getRegisteredComponent("obsFromFragmentTagHandler", SubstitutionTagHandler.class));
+	}
+	
+	@Test 
+	public void shouldHandleEditingOfSingleObsCorrectly() throws Exception {
+		new RegressionTestHelper() {
+
+			@Override
+			public String getFormName() {
+				return "ObsFromFragment-withSingleObs";
+			}
+			
+			@Override
+			protected String getXmlDatasetPath() {
+				return "org/openmrs/module/htmlformentryui/include/";
+			}
+			
+			@Override
+			public String[] widgetLabels() {
+				return new String[] { "Date:", "Location:", "Provider:", "Allergy Date:" };
+			}
+			
+			@Override
+			public boolean doEditEncounter() {
+				return true;
+			}
+			
+			@Override
+			public void setupRequest(MockHttpServletRequest request, Map<String, String> widgets) {
+				request.addParameter(widgets.get("Date:"), dateAsString(new Date()));
+				request.addParameter(widgets.get("Location:"), "2");
+				request.addParameter(widgets.get("Provider:"), "502");
+				// In the test context, the available UiUtils instance doesn't have a FragmentIncluder hence html will
+				// not be generated to map the field name to value while handling submission.
+				// (This is hacky, but I don't see a better way to do it.)
+				request.addParameter("Allergy Date", "2014-02-11");
+			}
+			
+			@Override
+            public void testResults(SubmissionResults results) {
+				results.assertNoErrors();
+				results.assertEncounterCreated();
+				results.assertProvider(502);
+				results.assertLocation(2);
+				
+				Set<Obs> existingObs = results.getEncounterCreated().getAllObs(true);
+				Assert.assertEquals(1, existingObs.size());
+				Assert.assertEquals("2014-02-11", dateAsString(existingObs.iterator().next().getValueDatetime()));
+				Assert.assertTrue(retainVoidedObs(existingObs).isEmpty());
+			};
+			
+			@Override
+			public String[] widgetLabelsForEdit() {
+				return new String[] { "Allergy Date:" };
+			}
+			
+			@Override
+			public void setupEditRequest(MockHttpServletRequest request, Map<String, String> widgets) {
+				// In the test context, the available UiUtils instance doesn't have a FragmentIncluder hence html will
+				// not be generated to map the field name to value while handling submission.
+				// (This is hacky, but I don't see a better way to do it.)
+				request.addParameter("Allergy Date", "2015-02-11");
+			}
+			
+			@Override
+			public void testEditedResults(SubmissionResults results) {				
+				Set<Obs> existingObs = results.getEncounterCreated().getObs();
+				List<Obs> voidedObs = retainVoidedObs(results.getEncounterCreated().getAllObs(true));
+
+				Assert.assertEquals(1, existingObs.size());
+				Assert.assertEquals(1, voidedObs.size());
+
+				// Verify new value
+				Assert.assertEquals("2015-02-11", dateAsString(existingObs.iterator().next().getValueDatetime()));
+				// Verify old value
+				Assert.assertEquals("2014-02-11", dateAsString(voidedObs.get(0).getValueDatetime()));
+			}
+			
+		}.run();
+		
+	}
+	
+	@Test 
+	public void shouldHandleEditingOfObsGroupMemberCorrectly() throws Exception {
+		new RegressionTestHelper() {
+
+			@Override
+			public String getFormName() {
+				return "ObsFromFragment-withObsGroup";
+			}
+			
+			@Override
+			protected String getXmlDatasetPath() {
+				return "org/openmrs/module/htmlformentryui/include/";
+			}
+			
+			@Override
+			public String[] widgetLabels() {
+				return new String[] { "Date:", "Location:", "Provider:", "Allergy Date:" };
+			}
+			
+			@Override
+			public boolean doEditEncounter() {
+				return true;
+			}
+			
+			@Override
+			public void setupRequest(MockHttpServletRequest request, Map<String, String> widgets) {
+				request.addParameter(widgets.get("Date:"), dateAsString(new Date()));
+				request.addParameter(widgets.get("Location:"), "2");
+				request.addParameter(widgets.get("Provider:"), "502");
+				// In the test context, the available UiUtils instance doesn't have a FragmentIncluder hence html will
+				// not be generated to map the field name to value while handling submission.
+				// (This is hacky, but I don't see a better way to do it.)
+				request.addParameter("Allergy Date", "2019-04-11");
+			}
+			
+			@Override
+            public void testResults(SubmissionResults results) {
+				results.assertNoErrors();
+				results.assertEncounterCreated();
+						
+				Set<Obs> existingObs = results.getEncounterCreated().getObs();
+				Assert.assertEquals(1, existingObs.size());
+				Assert.assertEquals("2019-04-11", dateAsString(existingObs.iterator().next().getValueDatetime()));
+				Assert.assertTrue(retainVoidedObs(results.getEncounterCreated().getAllObs(true)).isEmpty());
+			};
+			
+			@Override
+			public String[] widgetLabelsForEdit() {
+				return new String[] { "Allergy Date:" };
+			}
+			
+			@Override
+			public void setupEditRequest(MockHttpServletRequest request, Map<String, String> widgets) {
+				// In the test context, the available UiUtils instance doesn't have a FragmentIncluder hence html will
+				// not be generated to map the field name to value while handling submission.
+				// (This is hacky, but I don't see a better way to do it.)
+				request.addParameter("Allergy Date", "2020-05-04");
+			}
+			
+			@Override
+			public void testEditedResults(SubmissionResults results) {				
+				Set<Obs> existingObs = results.getEncounterCreated().getObs();
+				List<Obs> voidedObs = retainVoidedObs(results.getEncounterCreated().getAllObs(true));
+
+				Assert.assertEquals(1, existingObs.size());
+				Assert.assertEquals(1, voidedObs.size());
+
+				// Verify new value
+				Assert.assertEquals("2020-05-04", dateAsString(existingObs.iterator().next().getValueDatetime()));
+				// Verify old value
+				Assert.assertEquals("2019-04-11", dateAsString(voidedObs.get(0).getValueDatetime()));
+			}
+			
+		}.run();
+	}
+	
+	private List<Obs> retainVoidedObs(Set<Obs> mixedObs) {
+		List<Obs> voidedObs = new ArrayList<Obs>();
+		for (Obs candidate : mixedObs) {
+			if (candidate.isVoided()) {
+				voidedObs.add(candidate);
+			}
+		}
+		return voidedObs;
+	}
+		
+}

--- a/api/src/test/resources/TestingApplicationContext.xml
+++ b/api/src/test/resources/TestingApplicationContext.xml
@@ -21,9 +21,9 @@
         <!--  default properties must be set in the hibernate.default.properties -->
     </bean>
 
-    <!--<bean id="coreResourceFactory" class="org.openmrs.ui.framework.resource.ResourceFactory"/>-->
-    <!--<bean id="conversionService" class="org.openmrs.module.uiframework.UiFrameworkConversionServiceFactoryBean"/>-->
-    <!--<bean id="uiUtils" class="org.openmrs.ui.framework.BasicUiUtils" init-method="init"/>-->
+    <bean id="uiUtils" class="org.openmrs.ui.framework.BasicUiUtils" init-method="init"/>
+  	<bean id="conversionService" class="org.openmrs.module.uiframework.UiFrameworkConversionServiceFactoryBean"/>
+  	<bean id="obsFromFragmentTagHandler" class="org.openmrs.module.htmlformentryui.tag.ObsFromFragmentTagHandler"/>
 
 </beans>
 

--- a/api/src/test/resources/org/openmrs/module/htmlformentryui/include/ObsFromFragment-withObsGroup.xml
+++ b/api/src/test/resources/org/openmrs/module/htmlformentryui/include/ObsFromFragment-withObsGroup.xml
@@ -1,0 +1,16 @@
+<htmlform>
+	Date: <encounterDate/>
+	Location: <encounterLocation/>
+	Provider: <encounterProvider role="Provider"/>
+	
+	<section>
+			<obsgroup groupingConceptId="3040">
+		        Allergy Date: <obsFromFragment
+									  fragment="field/datetimepicker"
+									  provider="uicommons"
+									  conceptId="1119"
+									  initFragmentParamName="defaultDate"
+									  fragmentParams="id=end_date&amp;formFieldName=Allergy Date&amp;label=&amp;useTime=true&amp;endDate=$formGeneratedDatetime"/>
+			</obsgroup>
+	</section>
+</htmlform>

--- a/api/src/test/resources/org/openmrs/module/htmlformentryui/include/ObsFromFragment-withSingleObs.xml
+++ b/api/src/test/resources/org/openmrs/module/htmlformentryui/include/ObsFromFragment-withSingleObs.xml
@@ -1,0 +1,11 @@
+<htmlform>
+	Date: <encounterDate/>
+	Location: <encounterLocation/>
+	Provider: <encounterProvider role="Provider"/>
+	Allergy Date: <obsFromFragment
+					  fragment="field/datetimepicker"
+					  provider="uicommons"
+					  conceptId="1119"
+					  initFragmentParamName="defaultDate"
+					  fragmentParams="id=end_date&amp;formFieldName=Allergy Date&amp;label=&amp;useTime=true&amp;endDate=$formGeneratedDatetime"/>
+</htmlform>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -46,6 +46,7 @@
             <type>jar</type>
             <scope>provided</scope>
         </dependency>
+        
         <dependency>
             <groupId>org.openmrs.web</groupId>
             <artifactId>openmrs-web</artifactId>
@@ -53,7 +54,15 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-
+        
+        <dependency>
+            <groupId>org.openmrs.api</groupId>
+            <artifactId>openmrs-api</artifactId>
+            <version>${openMRSVersion}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        
         <dependency>
             <groupId>rubygems</groupId>
             <artifactId>compass</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<openMRSVersion>1.10.4</openMRSVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <htmlformentryVersion>3.9.2</htmlformentryVersion>
-        <uiframeworkVersion>3.9</uiframeworkVersion>
+        <uiframeworkVersion>3.3.1</uiframeworkVersion>
         <appframeworkVersion>2.9</appframeworkVersion>
         <appuiVersion>1.7</appuiVersion>
         <emrapiVersion>1.18</emrapiVersion>
@@ -77,7 +77,15 @@
                 <version>${htmlformentryVersion}</version>
                 <scope>provided</scope>
             </dependency>
-						
+			
+			<dependency>
+                <groupId>org.openmrs.module</groupId>
+                <artifactId>htmlformentry-api</artifactId>
+                <version>${htmlformentryVersion}</version>
+                <type>test-jar</type>
+                <scope>test</scope>
+            </dependency>
+            			
 			<dependency>
 				<groupId>org.openmrs.module</groupId>
 				<artifactId>uiframework-api</artifactId>
@@ -177,6 +185,12 @@
 				<version>${openMRSVersion}</version>
 				<type>pom</type>
 				<scope>test</scope>
+				<exclusions>
+					<exclusion>
+						<artifactId>mockito-all</artifactId>
+						<groupId>org.mockito</groupId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 						
 			<!-- End OpenMRS core -->

--- a/pom.xml
+++ b/pom.xml
@@ -1,42 +1,42 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-	<groupId>org.openmrs.module</groupId>
-	<artifactId>htmlformentryui</artifactId>
-	<version>1.11.0-SNAPSHOT</version>
-	<packaging>pom</packaging>
-	<name>HTML Form Entry UI Framework Integration Module</name>
-	<description>Pages and Fragments for using the HTML Form Entry module along with the UI Framework</description>
-	<url>https://wiki.openmrs.org/display/docs/HTML+Form+Entry+UI+Framework+Integration+Module+Module</url>
-	
-	<developers>
-		<developer>
-			<name>OpenMRS</name>
-		</developer>
-	</developers>
-	
-	<organization>
-		<name>OpenMRS</name>
-		<url>http://openmrs.org</url>
-	</organization>
-
-	<scm>
+    <groupId>org.openmrs.module</groupId>
+    <artifactId>htmlformentryui</artifactId>
+    <version>1.11.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>HTML Form Entry UI Framework Integration Module</name>
+    <description>Pages and Fragments for using the HTML Form Entry module along with the UI Framework</description>
+    
+    <url>https://wiki.openmrs.org/display/docs/HTML+Form+Entry+UI+Framework+Integration+Module+Module</url>
+    
+    <developers>
+        <developer>
+            <name>OpenMRS</name>
+        </developer>
+    </developers>
+    <organization>
+        <name>OpenMRS</name>
+        <url>http://openmrs.org</url>
+    </organization>
+    
+    <scm>
         <connection>scm:git:git@github.com:openmrs/openmrs-module-htmlformentryui.git</connection>
         <developerConnection>scm:git:git@github.com:openmrs/openmrs-module-htmlformentryui.git</developerConnection>
         <url>scm:git:git@github.com:openmrs/openmrs-module-htmlformentryui.git</url>
-	  <tag>HEAD</tag>
-  </scm>
-
-	<modules>
-		<module>api</module>
-		<module>omod</module>
-	</modules>
-	
-	<properties>
-		<openMRSVersion>1.10.4</openMRSVersion>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <tag>HEAD</tag>
+    </scm>
+    
+    <modules>
+        <module>api</module>
+        <module>omod</module>
+    </modules>
+    
+    <properties>
+        <openMRSVersion>1.10.4</openMRSVersion>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <htmlformentryVersion>3.9.2</htmlformentryVersion>
-        <uiframeworkVersion>3.3.1</uiframeworkVersion>
+        <uiframeworkVersion>3.9</uiframeworkVersion>
         <appframeworkVersion>2.9</appframeworkVersion>
         <appuiVersion>1.7</appuiVersion>
         <emrapiVersion>1.18</emrapiVersion>
@@ -46,7 +46,7 @@
         <calculationVersion>1.2</calculationVersion>
         <serializationXstreamVersion>0.2.12</serializationXstreamVersion>
     </properties>
-
+    
     <dependencyManagement>
         <dependencies>
             <!-- we explicitly use version 3.2.10 since 3.2.11 has a bug which was giving us issues,
@@ -60,202 +60,178 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
-		<dependencies>
-
-			<!-- Begin OpenMRS modules -->
-			<dependency>
-				<groupId>org.openmrs.module</groupId>
-				<artifactId>htmlformentry-api</artifactId>
-				<version>${htmlformentryVersion}</version>
-				<scope>provided</scope>
-			</dependency>
-
-            <dependency>
-                <groupId>org.openmrs.module</groupId>
-                <artifactId>htmlformentry-api-1.10</artifactId>
-                <version>${htmlformentryVersion}</version>
-                <scope>provided</scope>
-            </dependency>
-			
-			<dependency>
-                <groupId>org.openmrs.module</groupId>
-                <artifactId>htmlformentry-api</artifactId>
-                <version>${htmlformentryVersion}</version>
-                <type>test-jar</type>
-                <scope>test</scope>
-            </dependency>
-            			
-			<dependency>
-				<groupId>org.openmrs.module</groupId>
-				<artifactId>uiframework-api</artifactId>
-				<version>${uiframeworkVersion}</version>
-				<scope>provided</scope>
-			</dependency>
-
-            <dependency>
-                <groupId>org.openmrs.module</groupId>
-                <artifactId>appframework-api</artifactId>
-                <version>${appframeworkVersion}</version>
-                <scope>provided</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.openmrs.module</groupId>
-                <artifactId>appui-api</artifactId>
-                <version>${appuiVersion}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.openmrs.module</groupId>
-                <artifactId>appui-api</artifactId>
-                <version>${appuiVersion}</version>
-                <type>test-jar</type>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.openmrs.module</groupId>
-                <artifactId>uicommons-api</artifactId>
-                <version>${uicommonsVersion}</version>
-                <scope>provided</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.openmrs.module</groupId>
-                <artifactId>emrapi-api</artifactId>
-                <version>${emrapiVersion}</version>
-                <scope>provided</scope>
-            </dependency>
-            
-            <dependency>
-                <groupId>org.openmrs.module</groupId>
-                <artifactId>emrapi-api-1.10</artifactId>
-                <version>${emrapiVersion}</version>
-                <scope>provided</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.openmrs.module</groupId>
-                <artifactId>providermanagement-api</artifactId>
-                <version>${providermanagementVersion}</version>
-                <scope>provided</scope>
-            </dependency>
-			<!-- End OpenMRS modules -->
-			
-
-			<!-- Begin OpenMRS core -->
-			
-			<dependency>
-				<groupId>org.openmrs.api</groupId>
-				<artifactId>openmrs-api</artifactId>
-				<version>${openMRSVersion}</version>
-				<type>jar</type>
-				<scope>provided</scope>
-                <!-- The javassist version that comes with the platform doesn't support java 8
+    
+    <dependencies>
+        <!-- Begin OpenMRS modules -->
+        <dependency>
+            <groupId>org.openmrs.module</groupId>
+            <artifactId>htmlformentry-api</artifactId>
+            <version>${htmlformentryVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openmrs.module</groupId>
+            <artifactId>htmlformentry-api-1.10</artifactId>
+            <version>${htmlformentryVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openmrs.module</groupId>
+            <artifactId>htmlformentry-api</artifactId>
+            <version>${htmlformentryVersion}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openmrs.module</groupId>
+            <artifactId>uiframework-api</artifactId>
+            <version>${uiframeworkVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openmrs.module</groupId>
+            <artifactId>appframework-api</artifactId>
+            <version>${appframeworkVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openmrs.module</groupId>
+            <artifactId>appui-api</artifactId>
+            <version>${appuiVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openmrs.module</groupId>
+            <artifactId>appui-api</artifactId>
+            <version>${appuiVersion}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openmrs.module</groupId>
+            <artifactId>uicommons-api</artifactId>
+            <version>${uicommonsVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openmrs.module</groupId>
+            <artifactId>emrapi-api</artifactId>
+            <version>${emrapiVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openmrs.module</groupId>
+            <artifactId>emrapi-api-1.10</artifactId>
+            <version>${emrapiVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openmrs.module</groupId>
+            <artifactId>providermanagement-api</artifactId>
+            <version>${providermanagementVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- End OpenMRS modules -->
+        <!-- Begin OpenMRS core -->
+        <dependency>
+            <groupId>org.openmrs.api</groupId>
+            <artifactId>openmrs-api</artifactId>
+            <version>${openMRSVersion}</version>
+            <type>jar</type>
+            <scope>provided</scope>
+            <!-- The javassist version that comes with the platform doesn't support java 8
                      powermock-module-junit4 which is another dependency that comes with the platform and
                      also ships with a later version of javassist that is actually compatible anyways,
                      therefore we need to exclude the javassist version that comes with the platform
                      otherwise some tests that use mocks will fail -->
-                <exclusions>
-                    <exclusion>
-                        <groupId>javassist</groupId>
-                        <artifactId>javassist</artifactId>
-                    </exclusion>
-                </exclusions>
-			</dependency>
-
-			<dependency>
-				<groupId>org.openmrs.api</groupId>
-				<artifactId>openmrs-api</artifactId>
-				<version>${openMRSVersion}</version>
-				<type>test-jar</type>
-				<scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>javassist</groupId>
-                        <artifactId>javassist</artifactId>
-                    </exclusion>
-                </exclusions>
-			</dependency>
-
-			<dependency>
-				<groupId>org.openmrs.test</groupId>
-				<artifactId>openmrs-test</artifactId>
-				<version>${openMRSVersion}</version>
-				<type>pom</type>
-				<scope>test</scope>
-				<exclusions>
-					<exclusion>
-						<artifactId>mockito-all</artifactId>
-						<groupId>org.mockito</groupId>
-					</exclusion>
-				</exclusions>
-			</dependency>
-						
-			<!-- End OpenMRS core -->
-
-            <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>servlet-api</artifactId>
-                <version>2.5</version>
-                <scope>provided</scope>
-            </dependency>
-
-            <!-- OpenMRS modules simply required to fire up the application context when running component tests -->
-
-            <dependency>
-                <groupId>org.openmrs.module</groupId>
-                <artifactId>reporting-api</artifactId>
-                <version>${reportingVersion}</version>
-                <scope>provided</scope>
-            </dependency>
-
-
-            <dependency>
-                <groupId>org.openmrs.module</groupId>
-                <artifactId>calculation-api</artifactId>
-                <version>${calculationVersion}</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.openmrs.module</groupId>
-                <artifactId>serialization.xstream-api</artifactId>
-                <version>${serializationXstreamVersion}</version>
-                <scope>test</scope>
-            </dependency>
-            
-            <dependency>
-                <groupId>org.openmrs.module</groupId>
-                <artifactId>serialization.xstream-api-1.10</artifactId>
-                <version>${serializationXstreamVersion}</version>
-                <scope>test</scope>
-            </dependency>
-
-		</dependencies>
-
-	<build>
-		<pluginManagement>
-			<plugins>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-compiler-plugin</artifactId>
-					<configuration>
-						<target>1.6</target>
-						<source>1.6</source>
-					</configuration>
-				</plugin>
-				<plugin>
-					<groupId>org.openmrs.maven.plugins</groupId>
-					<artifactId>maven-openmrs-plugin</artifactId>
-					<version>1.0.1</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-dependency-plugin</artifactId>
-					<version>2.4</version>
-				</plugin>
+            <exclusions>
+                <exclusion>
+                    <groupId>javassist</groupId>
+                    <artifactId>javassist</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.openmrs.api</groupId>
+            <artifactId>openmrs-api</artifactId>
+            <version>${openMRSVersion}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>javassist</groupId>
+                    <artifactId>javassist</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.openmrs.test</groupId>
+            <artifactId>openmrs-test</artifactId>
+            <version>${openMRSVersion}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>mockito-all</artifactId>
+                    <groupId>org.mockito</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- End OpenMRS core -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <version>2.5</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- OpenMRS modules simply required to fire up the application context when running component tests -->
+        <dependency>
+            <groupId>org.openmrs.module</groupId>
+            <artifactId>reporting-api</artifactId>
+            <version>${reportingVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openmrs.module</groupId>
+            <artifactId>calculation-api</artifactId>
+            <version>${calculationVersion}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openmrs.module</groupId>
+            <artifactId>serialization.xstream-api</artifactId>
+            <version>${serializationXstreamVersion}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openmrs.module</groupId>
+            <artifactId>serialization.xstream-api-1.10</artifactId>
+            <version>${serializationXstreamVersion}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                        <target>1.6</target>
+                        <source>1.6</source>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.openmrs.maven.plugins</groupId>
+                    <artifactId>maven-openmrs-plugin</artifactId>
+                    <version>1.0.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
                 <!-- The 2.10 version of this plugin released in Sept 2014 leads to opaque errors and a lot of:
                  [ERROR] java.lang.ClassCastException: com.sun.tools.javadoc.ClassDocImpl cannot be cast to com.sun.javadoc.AnnotationTypeDoc
                  We manually override to use the prior version which works fine.
@@ -295,28 +271,28 @@
                     </configuration>
                 </plugin>
             </plugins>
-		</pluginManagement>
-	</build>
+        </pluginManagement>
+    </build>
 
-	<repositories>
-		<repository>
-			<id>openmrs-repo</id>
-			<name>OpenMRS Nexus Repository</name>
-			<url>http://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
-		</repository>
-	</repositories>
-
-	<pluginRepositories>
-		<pluginRepository>
-			<id>openmrs-repo</id>
-			<name>OpenMRS Nexus Repository</name>
-			<url>http://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</pluginRepository>
-	</pluginRepositories>
-
+    <repositories>
+        <repository>
+            <id>openmrs-repo</id>
+            <name>OpenMRS Nexus Repository</name>
+            <url>http://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
+        </repository>
+    </repositories>
+    
+    <pluginRepositories>
+        <pluginRepository>
+            <id>openmrs-repo</id>
+            <name>OpenMRS Nexus Repository</name>
+            <url>http://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+    
     <distributionManagement>
         <repository>
             <id>openmrs-repo-modules</id>
@@ -329,5 +305,5 @@
             <url>http://mavenrepo.openmrs.org/nexus/content/repositories/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
-
+    
 </project>


### PR DESCRIPTION
 **Issue updating Obs**

This [previous commit](https://github.com/openmrs/openmrs-module-htmlformentryui/commit/4309506c0ae338a777292c57f92cad7e21adedb9) introduced a few regressions in the way the `<obsFromFragment/>` tag handles edit modes for single obs fields. 

This is a followup PR that resolves this issue and also expanded on the test coverage to be sure we curb all possible regressions.

**Broken widget - datetimepicker widget**

This also fixes the broke UI alignment of the datetimepicker widget as demonstrated in the screenshot below.
![screencapture-localhost-8080-openmrs-htmlformentryui-htmlform-editHtmlFormWithStandardUi-page-2020-05-04-23_37_00](https://user-images.githubusercontent.com/26084581/81011275-54447a80-8e60-11ea-8a5b-84849dd06341.png)
Community ticket: https://issues.openmrs.org/browse/HTML-706