### PR TITLE
HTML-736 - RegressionTestHelper class not found

### DIFF
--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -189,8 +189,8 @@
 						<configuration>
 							<includeGroupIds>${project.parent.groupId}</includeGroupIds>
 							<includeArtifactIds>${project.parent.artifactId}-api</includeArtifactIds>
-							<excludeTransitive>true</excludeTransitive>
-							<includes>**/*</includes>
+							<includeScope>compile</includeScope>
+							<includes>**\/*.xml,**\/*.properties</includes>
 							<outputDirectory>${project.build.directory}/classes</outputDirectory>
 						</configuration>
 					</execution>


### PR DESCRIPTION
@cioan can you please look this over, build the module from this branch, and confirm that everything starts up and works correctly on your local environment that failed with the release version?

@mks-d / @samuelmale  - review welcome!