### PR TITLE
RA-1875: EMPT97 Fixed XSS Vulnerability in returnUrl parameter of HTML Form

### DIFF
--- a/omod/src/main/java/org/openmrs/module/htmlformentryui/page/controller/htmlform/BaseEnterHtmlFormPageController.java
+++ b/omod/src/main/java/org/openmrs/module/htmlformentryui/page/controller/htmlform/BaseEnterHtmlFormPageController.java
@@ -14,6 +14,7 @@
 
 package org.openmrs.module.htmlformentryui.page.controller.htmlform;
 
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.Form;
 import org.openmrs.Patient;
@@ -71,7 +72,8 @@ public abstract class BaseEnterHtmlFormPageController {
 			throw new IllegalArgumentException("Couldn't find a form");
 		}
 		
-		returnUrl = HtmlFormUtil.determineReturnUrl(returnUrl, returnProvider, returnPage, currentPatient, visit, ui);
+		returnUrl = HtmlFormUtil.determineReturnUrl(StringEscapeUtils.escapeHtml(returnUrl), returnProvider, returnPage,
+		    currentPatient, visit, ui);
 		returnLabel = HtmlFormUtil.determineReturnLabel(returnLabel, currentPatient, ui);
 		
 		model.addAttribute("htmlForm", htmlForm);


### PR DESCRIPTION
### Description of What I Changed

I added encoding to returnUrl parameter of HTML form.

### Issue I Worked On

A script could be injected in the returnUrl parameter of Html forms. I encoded the parameter to prevent any XSS attacks.

Steps to reproduce the vulnerability:

1. Launch the OpenMRS application.
2. Login with username "Admin" and password "Admin123" with location as Inpatient Ward.
3. Go to find patient page and select any patient from the displayed list OR create a new patient with dummy details if there are not any patients registered.
4. Click on 'Start Visit'.
5. Click on 'Capture Vital'.
6. Change the 'returnUrl' parameter of the url of the page to `></script><script>alert(123)</script><script>` and press enter.

Output: A dialog box pops up with '123' written on it.

### Link to ticket
[RA-1875](https://issues.openmrs.org/browse/RA-1875)

@isears