### PR TITLE
RA-1875: EMPT93 Fixed XSS Vulnerability in Breadcrumbs of Capture Vitals Page

### DIFF
--- a/omod/src/main/webapp/pages/htmlform/enterHtmlFormWithSimpleUi.gsp
+++ b/omod/src/main/webapp/pages/htmlform/enterHtmlFormWithSimpleUi.gsp
@@ -29,7 +29,7 @@ ${ ui.includeFragment("coreapps", "patientHeader", [ patient: patient ]) }
 
     var breadcrumbs = _.flatten([
         { icon: "icon-home", link: '/' + OPENMRS_CONTEXT_PATH + '/index.htm' },
-        ${ breadcrumbMiddle } ,
+        ${ ui.encodeHtmlContent(breadcrumbMiddle) } ,
         { label: "${ ui.escapeJs(ui.format(htmlForm.form)) }" }
     ]);
 


### PR DESCRIPTION
### Description of What I Changed

Encoded patient name in the breadcrumbs of the capture vitals page.

### Issue I Worked On

An iframe/script injected in the name of a patient is executed in the breadcrumbs of the Capture Vitals page.

1. Launch the OpenMRS application.
2. Login with username "Admin" and password "Admin123" with location as Inpatient Ward.
3. Click on 'Register a patient'. 
4. Enter an iframe/script in the given name field and dummy details in the rest. For example, `Given Name: <iframe src="https://ncsu.edu"/> , Family Name: dummy , Gender: Male , Birthdate: 40 years , Address Line 1 : dummy`.
5. Click on 'Confirm'.
4. Click on 'Start Visit' and then 'Confirm' on the resulting dialog box.
5. Click on 'Capture Vitals'.

Output: The injected iframe is displayed in breadcrumbs at the top of the page.

### Link to ticket
[RA-1875](https://issues.openmrs.org/browse/RA-1875)

@isears 