### PR TITLE
MLW-1409, wait for all visit encounters to be displayed before calling afterShowVisitTable

### DIFF
--- a/omod/src/main/webapp/resources/scripts/flowsheet.js
+++ b/omod/src/main/webapp/resources/scripts/flowsheet.js
@@ -338,9 +338,6 @@
     flowsheet.showVisitTable = function() {
         jq(".flowsheet-edit-section").hide();
         jq(".flowsheet-section").show();
-        if (flowsheet.getFlowsheetExtension()) {
-            flowsheetExtension.afterShowVisitTable(flowsheet);
-        }
     };
 
     flowsheet.loadVisitTable = function() {
@@ -402,7 +399,11 @@
                 addLinksToVisitRow(table.find(".visit-table-row"), formName, encId, encTypeUuid);
                 section.append(table);
             }
-
+            if (loadingEncounters.length === 1) {
+              if (flowsheet.getFlowsheetExtension()) {
+                flowsheetExtension.afterShowVisitTable(flowsheet);
+              }
+            }
             if (showVisitTable) {
                 jq('.flowsheet-edit-section').empty();
                 flowsheet.toggleViewFlowsheet();

--- a/omod/src/main/webapp/resources/scripts/flowsheet.js
+++ b/omod/src/main/webapp/resources/scripts/flowsheet.js
@@ -400,6 +400,8 @@
                 section.append(table);
             }
             if (loadingEncounters.length === 1) {
+              // this is the last visit encounter to be loaded into the visit table
+              // the loadHtmlFormForEncounter.always() will be called after this function(data) completes
               if (flowsheet.getFlowsheetExtension()) {
                 flowsheetExtension.afterShowVisitTable(flowsheet);
               }
@@ -452,6 +454,7 @@
             "formName": formName,
             "encounterDate": encounterDate != null ? encounterDate : "",
         }), action).always( function() {
+            // the following code is executed after the action callback function is complete
             var index = loadingEncounters.indexOf(encounterId);
             if (index > -1) {
                 // the encounter visit was successfully loaded into the table


### PR DESCRIPTION
@mseaton , here is the small change that assures that the afterShowVisitTable extension function is called after all visit encounters are inserted in the visit table. The reason I had to change if (loadingEncounters.length === 0) to if (loadingEncounters.length === 1) is because this section of the code, function(data)
https://github.com/openmrs/openmrs-module-htmlformentryui/blob/master/omod/src/main/webapp/resources/scripts/flowsheet.js#L371

is called before the https://github.com/openmrs/openmrs-module-htmlformentryui/blob/master/omod/src/main/webapp/resources/scripts/flowsheet.js#L454

`}), action).always( function() {
            var index = loadingEncounters.indexOf(encounterId);
            if (index > -1) {
                // the encounter visit was successfully loaded into the table
                loadingEncounters.splice(index, 1);
            }
`
I could refactor the var loadHtmlFormForEncounter  function and remove the .always(). I could remove the code about removing entries from the loadingEncounters in the callback function(data). It does not look that that array is used anywhere else but in the flowsheet.loadIntoFlowsheet function. Please let me know what you think. Thanks!